### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# Tab indentation
+[*.{js,css,html}]
+indent_style = tab
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
[Editorconfig](http://EditorConfig.org) is a nice plugin that allows us to have the same styling rules across all developers and computers. It automatically integrates with IDEs such as WebStorm and sets the styling rules as defined in the config file.

This should solve any inconsistent styling issues.