### PR TITLE
Change get API

### DIFF
--- a/controllers/API/announcement.js
+++ b/controllers/API/announcement.js
@@ -52,7 +52,7 @@ router.post('/API/announcement', auth.isAuthorised("ALTER_ANNOUNCEMENTS"), funct
 
 router.get('/API/announcement', function (req, res) {
 	Announcement
-		.find({})
+		.find(req.query)
 		.sort({ $natural: -1 })
 		.limit(req.query.count || 200)
 		.exec(function (err, announcements) {

--- a/controllers/API/comment.js
+++ b/controllers/API/comment.js
@@ -99,7 +99,7 @@ router.put('/API/forum/comment', function (req, res) {
 
 router.get('/API/forum/comment', function (req, res) {
 	Comment
-		.findOne({ '_id': req.query.id })
+		.findOne(req.query)
 		.exec(function (err, comment) {
 			if (err) {
 				res.status(400);

--- a/controllers/API/generalinfo.js
+++ b/controllers/API/generalinfo.js
@@ -51,7 +51,7 @@ router.post('/API/generalinfo', auth.isAuthorised("ALTER_GENERAL_INFO"), functio
 
 router.get('/API/generalinfo', function (req, res) {
 	Generalinfo
-		.find({})
+		.find(req.query)
 		.sort({ $natural: -1 })
 		.limit(req.query.count || 200)
 		.exec(function (err, generalinfo) {

--- a/controllers/API/lecturer.js
+++ b/controllers/API/lecturer.js
@@ -80,7 +80,7 @@ router.put('/API/lecturer', auth.isAuthorised("ALTER_LECTURERS"), function (req,
 
 router.get('/API/lecturer', function (req, res) {
 	Lecturer
-		.find({})
+		.find(req.query)
 		.sort({ $natural: -1 })
 		.limit(req.query.count || 200)
 		.exec(function (err, lecturers) {

--- a/controllers/API/school.js
+++ b/controllers/API/school.js
@@ -25,27 +25,15 @@ router.post('/API/school', auth.isAuthorised("ALTER_SCHOOLS"), function (req, re
 });
 
 router.get('/API/school', function (req, res) {
-	if (req.query.id) {
-		School.findById(req.query.id, function (err, school) {
-			if (typeof school === 'undefined' || err) {
-				logger.warning('Can not find school\n' + (err || 'Wrong id provided'));
+	School
+		.find(req.query)
+		.limit(req.query.count || 10)
+		.exec(function (err, schools) {
+			if (err) {
+				logger.warning('Can not retrieve schools\n' + err);
 				res.sendStatus(400);
-			} else {
-				res.send(school);
-			}
+			} else res.send(schools);
 		});
-	} else {
-		School
-			.find({})
-			.limit(req.query.count || 10)
-			.exec(function (err, schools) {
-				if (err) {
-					logger.warning('Can not retrieve schools\n' + err);
-					res.sendStatus(400);
-				} else res.send(schools);
-			});
-	}
-
 });
 
 // delete a school

--- a/controllers/API/thread.js
+++ b/controllers/API/thread.js
@@ -79,7 +79,7 @@ router.put('/API/forum/thread', function (req, res) {
 
 router.get('/API/forum/thread', function (req, res) {
 	Thread
-		.find({})
+		.find(req.query)
 		.sort({ $natural: -1 })
 		.limit(req.query.count || 200)
 		.exec(function (err, threads) {

--- a/controllers/API/user.js
+++ b/controllers/API/user.js
@@ -34,7 +34,7 @@ router.post('/API/user', auth.isAuthorised("ALTER_USERS"), function (req, res) {
 
 router.get('/API/user', auth.isAuthorised("VIEW_OPTIONS"), function (req, res) {
 	User
-		.find({}, ['_id', 'username', 'rank', 'school']) // Do not show hashed password
+		.find(req.query, ['_id', 'username', 'rank', 'school']) // Do not show hashed password
 		.limit(req.query.count || 20)
 		.exec(function (err, users) {
 			if (err) {


### PR DESCRIPTION
Adds more filtering options to the GET API as requested by Charles.
Every GET API will filter the results by any query parameter you give it. For example:

`GET /API/comment?author=daniel&parentThead=12&<any_property_you_can_think_of>=1`

Will return all comments that have satisfy:
`comment.author == "daniel"`
`comment.parentThread == "12"`
`comment.<any_property_you_can_think_of> == "1"`
