### PR TITLE
Fix api

### DIFF
--- a/controllers/API/announcement.js
+++ b/controllers/API/announcement.js
@@ -48,6 +48,7 @@ router.post("/API/announcement", auth.isAuthorised("ALTER_ANNOUNCEMENTS"), funct
 });
 
 router.get("/API/announcement", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Announcement

--- a/controllers/API/announcement.js
+++ b/controllers/API/announcement.js
@@ -48,7 +48,10 @@ router.post("/API/announcement", auth.isAuthorised("ALTER_ANNOUNCEMENTS"), funct
 });
 
 router.get("/API/announcement", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Announcement

--- a/controllers/API/comment.js
+++ b/controllers/API/comment.js
@@ -86,7 +86,10 @@ router.put("/API/forum/comment", function (req, res) {
 });
 
 router.get("/API/forum/comment", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	Comment
 		.find(req.query)
 		.exec(function (err, comment) {

--- a/controllers/API/comment.js
+++ b/controllers/API/comment.js
@@ -86,6 +86,7 @@ router.put("/API/forum/comment", function (req, res) {
 });
 
 router.get("/API/forum/comment", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	Comment
 		.find(req.query)
 		.exec(function (err, comment) {

--- a/controllers/API/event.js
+++ b/controllers/API/event.js
@@ -42,7 +42,10 @@ router.post("/API/event", auth.isAuthorised("ALTER_CALENDAR"), function (req, re
 
 
 router.get("/API/event", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	if (!calendar.setInterval(req.query, "week", 7)) {

--- a/controllers/API/event.js
+++ b/controllers/API/event.js
@@ -42,6 +42,7 @@ router.post("/API/event", auth.isAuthorised("ALTER_CALENDAR"), function (req, re
 
 
 router.get("/API/event", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	if (!calendar.setInterval(req.query, "week", 7)) {

--- a/controllers/API/generalinfo.js
+++ b/controllers/API/generalinfo.js
@@ -48,7 +48,10 @@ router.post("/API/generalinfo", auth.isAuthorised("ALTER_GENERAL_INFO"), functio
 });
 
 router.get("/API/generalinfo", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Generalinfo

--- a/controllers/API/generalinfo.js
+++ b/controllers/API/generalinfo.js
@@ -48,6 +48,7 @@ router.post("/API/generalinfo", auth.isAuthorised("ALTER_GENERAL_INFO"), functio
 });
 
 router.get("/API/generalinfo", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Generalinfo

--- a/controllers/API/lecturer.js
+++ b/controllers/API/lecturer.js
@@ -77,7 +77,10 @@ router.put("/API/lecturer", auth.isAuthorised("ALTER_LECTURERS"), function (req,
 });
 
 router.get("/API/lecturer", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Lecturer

--- a/controllers/API/lecturer.js
+++ b/controllers/API/lecturer.js
@@ -77,6 +77,7 @@ router.put("/API/lecturer", auth.isAuthorised("ALTER_LECTURERS"), function (req,
 });
 
 router.get("/API/lecturer", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Lecturer

--- a/controllers/API/school.js
+++ b/controllers/API/school.js
@@ -25,6 +25,7 @@ router.post("/API/school", auth.isAuthorised("ALTER_SCHOOLS"), function (req, re
 });
 
 router.get("/API/school", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	School

--- a/controllers/API/school.js
+++ b/controllers/API/school.js
@@ -25,7 +25,10 @@ router.post("/API/school", auth.isAuthorised("ALTER_SCHOOLS"), function (req, re
 });
 
 router.get("/API/school", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	School

--- a/controllers/API/thread.js
+++ b/controllers/API/thread.js
@@ -68,7 +68,10 @@ router.put("/API/forum/thread", function (req, res) {
 });
 
 router.get("/API/forum/thread", function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Thread

--- a/controllers/API/thread.js
+++ b/controllers/API/thread.js
@@ -68,6 +68,7 @@ router.put("/API/forum/thread", function (req, res) {
 });
 
 router.get("/API/forum/thread", function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	Thread

--- a/controllers/API/user.js
+++ b/controllers/API/user.js
@@ -32,6 +32,7 @@ router.post("/API/user", auth.isAuthorised("ALTER_USERS"), function (req, res) {
 });
 
 router.get("/API/user", auth.isAuthorised("VIEW_OPTIONS"), function (req, res) {
+	req.query._id = req.query._id || req.query.id;
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	User

--- a/controllers/API/user.js
+++ b/controllers/API/user.js
@@ -32,7 +32,10 @@ router.post("/API/user", auth.isAuthorised("ALTER_USERS"), function (req, res) {
 });
 
 router.get("/API/user", auth.isAuthorised("VIEW_OPTIONS"), function (req, res) {
-	req.query._id = req.query._id || req.query.id;
+	if (req.query.id) {
+		req.query._id = req.query.id;
+		delete req.query.id;
+	}
 	const count = parseInt(req.query.count);
 	delete req.query.count;
 	User

--- a/models/comment.js
+++ b/models/comment.js
@@ -12,7 +12,7 @@ const CommentSchema = new Schema({
 	},
 	created: {
 		type: Date,
-		default: Date.now()
+		default: Date.now
 	},
 	author: {
 		type: String,

--- a/models/thread.js
+++ b/models/thread.js
@@ -16,7 +16,7 @@ const ThreadSchema = new Schema({
 	},
 	created: {
 		type: Date,
-		default: Date.now()
+		default: Date.now
 	},
 	author: {
 		type: String,


### PR DESCRIPTION
This PR fixes the creation date of comments and threads. These were set to the time when the server was started due to a small mistake.
It also makes sure all `GET` requests allow both `id` and `_id` as the identifier parameter name