### PR TITLE
Parse html

### DIFF
--- a/public/dist/js/userRights.js
+++ b/public/dist/js/userRights.js
@@ -28,7 +28,7 @@ const UserRights = {
 	// A coordinator for a specific school. May only perform actions related to a specific school.
 	coordinator: [
 		"ACCESS_MAIN_OVERVIEW",
-		"ALTER_LECTURER",
+		"ALTER_LECTURERS",
 		"ALTER_GENERAL_INFO",
 		"ALTER_ANNOUNCEMENTS",
 		"ALTER_CALENDAR",

--- a/views/announcements.ejs
+++ b/views/announcements.ejs
@@ -56,6 +56,6 @@
 		</div>
 	</div>
 </div>
-<% include partials/modal %>
+<% include partials/modal.html %>
 </body>
 </html>

--- a/views/generalinfo.ejs
+++ b/views/generalinfo.ejs
@@ -56,7 +56,7 @@
 		</div>
 	</div>
 </div>
-<% include partials/modal %>
+<% include partials/modal.html %>
 
 </body>
 </html>

--- a/views/lecturerpage.ejs
+++ b/views/lecturerpage.ejs
@@ -28,7 +28,7 @@
 						 ng-src="{{ lecturer.imagepath || '/images/default/placeholder.png' }}" alt="Placeholder">
 					<h4 class="title">{{ lecturer.name }}</h4>
 					<div class="caption">
-						<div class="lead data-text">{{ lecturer.description }}</div>
+						<div class="lead data-text" ng-bind-html="lecturer.description"></div>
 						<a class="data-text website"
 						   href='{{ (lecturer.website.substring(0, 7) === "http://") ? lecturer.website : ("http://" + lecturer.website) }}'>{{
 							lecturer.website }}</a>


### PR DESCRIPTION
Fixes three issues:

-  Coordinators can now alter lecturers again
-  The description HTML is now parsed in the body of the blocks on the lecturer page.
- The modals in the announcement and generalinfo page are now correctly loaded.